### PR TITLE
Readme.md중 오해를 부를 수 있는 부분 수정+ torch설치시 pip버그회피

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,9 +144,15 @@ Singing Voice Conversion via diffusion model
         python run.py --config training/config_nsf.yaml --exp_name test --reset
         ```
     - Linux의 경우:
-    ```
-    CUDA_VISIBLE_DEVICES=0 python run.py --config training/config.yaml --exp_name test --reset
-    ```
+        - GPU 메모리가 6GB미만인 경우
+        ```
+        CUDA_VISIBLE_DEVICES=0 python run.py --config training/config.yaml --exp_name test --reset
+        ```
+        
+        - GPU메모리가 6GB이상인 경우
+        ```
+        CUDA_VISIBLE_DEVICES=0 python run.py --config training/config_nsf.yaml --exp_name test --reset
+        ```
     
     이어서 하고 싶을 경우
     

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Singing Voice Conversion via diffusion model
     ```
 4. library 설치 (이것도 설치 뭐 많이할거임 엔터엔터하면 댐)
     ```
-    pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu116
+    pip install torch==1.13.1+cu116 torchvision==0.14.1+cu116 torchaudio==0.13.1 --extra-index-url https://download.pytorch.org/whl/cu116
     pip install -r requirements.txt
     ```
 5. 환경 변수 세팅


### PR DESCRIPTION
Linux에서의 명령 설명중 오해를 부를 수 있는 부분을 수정했습니다. 
-6GB이상 메모리에서 리눅스도 config_nsf파일을 사용해야 44.1kHZ가 학습됩니다. 따라서 해당부분을 수정했습니다.

그리고 pip버그로 인해 버전을 명확히 하지 않는 경우 엉뚱한 버전이 설치되는 경우가 있다고 합니다. 따라서 torch==1.13.1+cu116 이런식으로 버전을 고정했습니다.

https://pytorch.org/get-started/previous-versions/
여기를 참고했습니다.