### PR TITLE
라이브러리 설치 부분 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,9 @@ https://github.com/wlsdml1114/DDSP-SVC-KOR
     ```
 4. library 설치 (이것도 설치 뭐 많이할거임 엔터엔터하면 댐)
     ```
-    pip install torch==1.13.1+cu116 torchvision==0.14.1+cu116 torchaudio==0.13.1 --extra-index-url https://download.pytorch.org/whl/cu116
     pip install -r requirements.txt
+    # 설치 후 CUDA 관련 library 설치
+    pip install torch==1.13.1+cu116 torchvision==0.14.1+cu116 torchaudio==0.13.1 --extra-index-url https://download.pytorch.org/whl/cu116
     ```
 5. 환경 변수 세팅
 


### PR DESCRIPTION
기존에는 CUDA를 위한 torch를 먼저 설치했으나

requirements.txt에있는 모듈 설치 중
설치했던 torch==1.13.1+cu116 모듈이 날아가고
최신 버전으로 설치되는 문제가 있었습니다.

이 문제를 해결하기 위해 설치 하는 순서를 변경했습니다.